### PR TITLE
Support contract methods with message argument

### DIFF
--- a/ContracsReSharperInterop.Test/RequiresTests.cs
+++ b/ContracsReSharperInterop.Test/RequiresTests.cs
@@ -49,9 +49,48 @@ namespace Test
 }";
 
             VerifyCSharpFix(originalCode, fixedCode, null, true);
-        }
+		}
 
-        [Fact]
+	    [Fact]
+	    public void SimpleMethodWithNotNullArgumentAndExceptionMessage()
+	    {
+		    const string originalCode = @"
+using System.Diagnostics.Contracts;
+
+namespace Test
+{
+    class Class
+    {
+        void Method(object arg)
+        {
+            Contract.Requires(arg != null, ""arg"");
+        }
+    }
+}";
+
+		    var expected = new DiagnosticResult(8, 28, "arg");
+
+		    VerifyCSharpDiagnostic(originalCode, expected);
+
+		    const string fixedCode = @"
+using System.Diagnostics.Contracts;
+using JetBrains.Annotations;
+
+namespace Test
+{
+    class Class
+    {
+        void Method([NotNull] object arg)
+        {
+            Contract.Requires(arg != null, ""arg"");
+        }
+    }
+}";
+
+		    VerifyCSharpFix(originalCode, fixedCode, null, true);
+	    }
+
+		[Fact]
         public void SimpleMethodWithReferenceEqualsNotNullArgument()
         {
             const string originalCode = @"

--- a/ContracsReSharperInterop/ExtensionMethods.cs
+++ b/ContracsReSharperInterop/ExtensionMethods.cs
@@ -70,8 +70,8 @@ namespace ContracsReSharperInterop
         {
             var arguments = node.ArgumentList.Arguments;
 
-            return arguments.Count == 1 // Contract.??? have just one argument
-                ? arguments.Single()?.Expression?.GetNotNullArgumentIdentifierSyntax<T>()
+            return arguments.Count == 1|| arguments.Count == 2 // Contract.??? number of arguments is 1 or 2 (latter with message)
+                ? arguments.First()?.Expression?.GetNotNullArgumentIdentifierSyntax<T>() // first or only argument is the condition
                 : null;
         }
 


### PR DESCRIPTION
In our source we have a lot of contracts using the message argument the contract methods (i.e. `Contract.Requires(settings != null, "settings")`. Please don't ask why :) So I made this little change and could use your extensions to auto implement [NotNull] for them. Maybe it is useful for others?